### PR TITLE
Mattthousand/screenshot fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ extension ViewController: UINavigationControllerDelegate {
 
 ```
 
-### SplitAnimation
+### SplitTransition
 
 <p align="center" >
 <br/>
@@ -71,12 +71,13 @@ extension ViewController: UINavigationControllerDelegate {
 <br/>
 </p>
 
-`SplitAnimation` exposes 4 key properties: 
+`SplitTransition` exposes 5 key properties: 
 
-1. `splitLocation` (optional, defaults to `0.0`) - y coordinate where the top and bottom views part
-2. `transitionDuration` (optional, defaults to `1.0`) - duration (in seconds) of the transition animation 
-3. `transitionDelay` (optional, defaults to `0.0`) - delay (in seconds) before the start of the transition animation
-4. `transitionType` (optional, defaults to `.Push`) - `.Push` or `.Pop`
+1. `screenshotScope` - (optional, defaults to `.View`) - determines whether top and bottom views are sourced from container view or entire window
+2. `splitLocation` (optional, defaults to `0.0`) - y coordinate where the top and bottom views part
+3. `transitionDuration` (optional, defaults to `1.0`) - duration (in seconds) of the transition animation 
+4. `transitionDelay` (optional, defaults to `0.0`) - delay (in seconds) before the start of the transition animation
+5. `transitionType` (optional, defaults to `.Push`) - `.Push`, `.Pop`, or `.Interactive`. Setting `transitionType` to `.Interactive` will allow users to control the progress of the transition with a drag gesture.
 
 Set these properties in your implementation of	`UINavigationControllerDelegateTransitioning`:
 
@@ -100,5 +101,4 @@ func navigationController(navigationController: UINavigationController,
     return currentTransition
 }
 ```
-
 

--- a/Shift-Demo/Shift-Demo/SplitTransitionAnimatedViewController.swift
+++ b/Shift-Demo/Shift-Demo/SplitTransitionAnimatedViewController.swift
@@ -78,6 +78,7 @@ extension SplitTransitionAnimatedViewController: UINavigationControllerDelegate 
                 let splitTransition = SplitTransition()
                 splitTransition.transitionDuration = 2.0
                 splitTransition.transitionType = .Push
+                splitTransition.screenshotScope = .Window
                 splitTransition.splitLocation = currentCell != nil ? CGRectGetMidY(currentCell!.frame) + navigationController.navigationBar.frame.size.height : CGRectGetMidY(view.frame) + navigationController.navigationBar.frame.size.height
                 currentTransition = splitTransition
             }

--- a/Shift-Demo/Shift-Demo/SplitTransitionInteractiveViewController.swift
+++ b/Shift-Demo/Shift-Demo/SplitTransitionInteractiveViewController.swift
@@ -80,6 +80,7 @@ extension SplitTransitionInteractiveViewController: UINavigationControllerDelega
                     initialNavigationControllerDelegate: initialNavigationControllerDelegate)
                 splitTransition.splitOffset = 50.0
                 splitTransition.splitLocation = currentSplitLocation
+                splitTransition.screenshotScope = .Window
                 currentTransition = splitTransition
             }
             else if (operation == .Pop && toVC == self) {

--- a/Source/Shift.xcodeproj/project.pbxproj
+++ b/Source/Shift.xcodeproj/project.pbxproj
@@ -94,9 +94,9 @@
 			buildPhases = (
 				B5F88B471C19D96C00D10000 /* Sources */,
 				B5F88B481C19D96C00D10000 /* Frameworks */,
+				3CFE16171C1FE06D007FE683 /* Swiftlint */,
 				B5F88B491C19D96C00D10000 /* Headers */,
 				B5F88B4A1C19D96C00D10000 /* Resources */,
-				3CFE16171C1FE06D007FE683 /* Swiftlint */,
 			);
 			buildRules = (
 			);

--- a/Source/Shift/Classes/SplitTransition.swift
+++ b/Source/Shift/Classes/SplitTransition.swift
@@ -225,7 +225,7 @@ extension SplitTransition: UIViewControllerAnimatedTransitioning {
             toVC = toVC,
             container = container,
             completion = completion else {
-                print("animation setup failed")
+                debugPrint("animation setup failed")
                 return
         }
 
@@ -533,7 +533,7 @@ private extension SplitTransition {
             CGContextFillRect(ctx, CGRect(x: 0.0, y: 0.0, width: viewFrame.width, height: viewFrame.height))
             fromVC?.view.layer.renderInContext(ctx)
         } else {
-            print("Unable to get current graphics context")
+            debugPrint("Unable to get current graphics context")
         }
 
         let screenshot = UIGraphicsGetImageFromCurrentImageContext()

--- a/Source/Shift/Classes/SplitTransition.swift
+++ b/Source/Shift/Classes/SplitTransition.swift
@@ -481,10 +481,10 @@ private extension SplitTransition {
         let height = containerView.frame.size.height ?? 0.0
 
         /// Top screen capture extends from split location to top of view
-        topSplitImageView.frame = CGRectMake(0.0, 0.0, width, splitLocation)
+        topSplitImageView.frame = CGRect(x: 0.0, y: 0.0, width: width, height: splitLocation)
 
         /// Bottom screen capture extends from split location to bottom of view
-        bottomSplitImageView.frame = CGRectMake(0.0, splitLocation, width, height - splitLocation)
+        bottomSplitImageView.frame = CGRect(x: 0.0, y: splitLocation, width: width, height: height - splitLocation)
 
         /// Store a distance figure to use to calculate percent complete for
         /// the interactive transition
@@ -497,7 +497,7 @@ private extension SplitTransition {
 
         if let ctx = UIGraphicsGetCurrentContext() {
             UIColor.blackColor().set()
-            CGContextFillRect(ctx, CGRectMake(0.0, 0.0, viewFrame.width, viewFrame.height))
+            CGContextFillRect(ctx, CGRect(x: 0.0, y: 0.0, width: viewFrame.width, height: viewFrame.height))
             fromVC?.view.layer.renderInContext(ctx)
         } else {
             print("Unable to get current graphics context")

--- a/Source/Shift/Classes/SplitTransition.swift
+++ b/Source/Shift/Classes/SplitTransition.swift
@@ -352,17 +352,35 @@ private extension SplitTransition {
         }
     }
 
-    /// Returns the view controller being navigated away from
+    /**
+    Return origin view controller.
+
+    - parameter transitionContext: an optional `UIViewControllerContextTransitioning`.
+
+    - returns: an optional `UIViewController`.
+    */
     func fromViewController(transitionContext: UIViewControllerContextTransitioning?) -> UIViewController? {
         return transitionContext?.viewControllerForKey(UITransitionContextFromViewControllerKey)
     }
 
-    /// Returns the view controller being navigated to
+    /**
+    Return destination view controller..
+
+    - parameter transitionContext: an optional `UIViewControllerContextTransitioning`.
+
+    - returns: an optional `UIViewController`.
+    */
     func toViewController(transitionContext: UIViewControllerContextTransitioning?) -> UIViewController? {
         return transitionContext?.viewControllerForKey(UITransitionContextToViewControllerKey)
     }
 
-    /// Returns the container view for the transition context
+    /**
+    Return the container view for the given transition context.
+
+    - parameter transitionContext: an optional `UIViewControllerContextTransitioning`.
+
+    - returns: the container `UIView` for the transition context.
+    */
     func containerView(transitionContext: UIViewControllerContextTransitioning?) -> UIView? {
         return transitionContext?.containerView()
     }
@@ -395,7 +413,15 @@ private extension SplitTransition {
         }
     }
 
-    /// Push Transition
+    /**
+    Push fromViewController onto navigation stack.
+
+    - parameter toOffset:           vertical offset at which to start interactive animation.
+    - parameter toViewController:   destination view controller.
+    - parameter fromViewController: origin view controller.
+    - parameter containerView:      container view for transition context.
+    - parameter completion:         completion handler.
+    */
     func push(toOffset: CGFloat = 0.0,
         toViewController: UIViewController,
         fromViewController: UIViewController,
@@ -429,7 +455,14 @@ private extension SplitTransition {
                 completion: completion)
     }
 
-    /// Pop Transition
+    /**
+     Pop fromViewController from navigation stack.
+
+     - parameter toViewController:   destination view controller.
+     - parameter fromViewController: origin view controller.
+     - parameter containerView:      container view for transition context.
+     - parameter completion:         completion handler.
+     */
     func pop(toViewController: UIViewController,
         fromViewController: UIViewController,
         containerView: UIView,

--- a/Source/Shift/Classes/SplitTransition.swift
+++ b/Source/Shift/Classes/SplitTransition.swift
@@ -466,7 +466,7 @@ private extension SplitTransition {
 
                     /// Make destination view controller's view visible again
                     toViewController.view.alpha = 1.0
-                    toViewController.navigationController?.navigationBarHidden = false
+                    toViewController.navigationController?.navigationBarHidden = self?.fromVC?.navigationController?.navigationBar.hidden ?? false
                     toViewController.navigationController?.delegate = self?.initialNavigationControllerDelegate
 
                     /// If a completion was passed as a parameter, execute it

--- a/Source/Shift/UIWindow+Screenshot.swift
+++ b/Source/Shift/UIWindow+Screenshot.swift
@@ -31,12 +31,13 @@ import Foundation
 
 extension UIWindow {
 
-    public class func screenShot() -> UIImage {
+    public class func screenshot() -> UIImage {
 
         // Generate image size depending on device orientation
-        let imageSize: CGSize = UIInterfaceOrientationIsPortrait(UIApplication.sharedApplication().statusBarOrientation) ? UIScreen.mainScreen().bounds.size : CGSizeMake(UIScreen.mainScreen().bounds.size.height, UIScreen.mainScreen().bounds.size.width)
+        let imageSize: CGSize = UIScreen.mainScreen().bounds.size
 
         UIGraphicsBeginImageContextWithOptions(imageSize, false, UIScreen.mainScreen().scale)
+        UIGraphicsBeginImageContext(UIScreen.mainScreen().bounds.size)
         let context: CGContextRef? = UIGraphicsGetCurrentContext()
 
         // Draw view hierarchy
@@ -57,18 +58,6 @@ extension UIWindow {
 
                 // Save the current graphics state
                 CGContextSaveGState(context)
-
-                // Move the graphics context to the center of the window
-                CGContextTranslateCTM(context, window.center.x, window.center.y)
-                CGContextConcatCTM(context, window.transform)
-
-                // Move the graphics context left and up
-                CGContextTranslateCTM(context,
-                    -window.bounds.size.width * window.layer.anchorPoint.x,
-                    -window.bounds.size.height * window.layer.anchorPoint.y)
-
-                // Rotate graphics context if in landscape mode or upside down
-                rotateContext(context: context, imageSize: imageSize)
 
                 // draw view hierarchy or render
                 if window.respondsToSelector(Selector("drawViewHierarchyInRect:")) {

--- a/Source/Shift/UIWindow+Screenshot.swift
+++ b/Source/Shift/UIWindow+Screenshot.swift
@@ -70,7 +70,7 @@ extension UIWindow {
         }
         else {
             // Log an error message in case of failure
-            print("unable to get current graphics context")
+            debugPrint("unable to get current graphics context")
         }
     }
 


### PR DESCRIPTION
Some of the `CGContext` rotation/manipulation I was doing in `UIWindow+Screenshot` was causing utter chaos for non-portrait device orientations. Here be the fixes.

Also in this PR is a new `enum`, `ScreenshotScope`, which gives users the ability to specify whether they'd like the entire window to be used to generate top and bottom split views, or just the transition's container view.

before:
![before](https://cloud.githubusercontent.com/assets/2637355/12052450/42e8372a-aedd-11e5-87f5-49a01781afac.gif)

after:
![after](https://cloud.githubusercontent.com/assets/2637355/12052451/45170224-aedd-11e5-8154-bb89bdef0790.gif)
